### PR TITLE
Add synthetic dataset pipeline and defect classifier web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pth
+*.pt
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# AI-potato-defect-detection
+# AI-Powered Potato Internal Defect Detector
+
+This repository hosts a minimal prototype for detecting internal potato
+defects such as hollow heart, black heart, or internal heat necrosis.
+A small convolutional neural network is trained on synthetic images of
+potato cross-sections and exposed via a Streamlit web application.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. (Optional) Create a synthetic dataset:
+   ```bash
+   python generate_dataset.py --outdir data --samples 200
+   ```
+   This creates `train` and `test` splits in the `data/` directory.
+
+## Training
+
+Train the CNN using the generated dataset:
+
+```bash
+python train.py --data-dir data --epochs 5
+```
+
+This writes `model.pth`, which is consumed by the web application.
+
+## Web UI
+
+Launch the Streamlit interface to classify images as **defect** or
+**healthy**:
+
+```bash
+streamlit run app.py
+```
+
+Upload an X-ray or NIR potato cross-section image to receive a
+prediction.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,52 @@
+"""Streamlit web app for potato defect detection."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+import torch
+from PIL import Image
+from torchvision import transforms
+
+from train import SimpleCNN
+
+
+def load_model(model_path: Path) -> torch.nn.Module:
+    model = SimpleCNN()
+    model.load_state_dict(torch.load(model_path, map_location="cpu"))
+    model.eval()
+    return model
+
+
+def predict(model: torch.nn.Module, image: Image.Image) -> str:
+    transform = transforms.Compose([
+        transforms.Grayscale(),
+        transforms.Resize((128, 128)),
+        transforms.ToTensor(),
+    ])
+    tensor = transform(image).unsqueeze(0)
+    with torch.no_grad():
+        outputs = model(tensor)
+        _, pred = torch.max(outputs, 1)
+    return ["defect", "healthy"][pred.item()]
+
+
+def main() -> None:
+    st.title("Potato Internal Defect Detector")
+    st.write("Upload an X-ray or NIR image of a potato cross-section to detect hidden defects.")
+    model_path = Path("model.pth")
+    if not model_path.exists():
+        st.error("Trained model not found. Please run train.py first.")
+        return
+
+    model = load_model(model_path)
+    uploaded = st.file_uploader("Choose an image", type=["png", "jpg", "jpeg"])
+    if uploaded is not None:
+        image = Image.open(uploaded)
+        st.image(image, caption="Uploaded image", use_column_width=True)
+        label = predict(model, image)
+        st.success(f"Prediction: {label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -1,0 +1,62 @@
+"""Generate a synthetic dataset of potato cross-section images.
+
+Healthy images are plain light circles. Defect images contain a dark
+spot representing internal issues like hollow heart or black heart.
+The script avoids heavy dependencies and relies solely on Pillow.
+"""
+from __future__ import annotations
+
+import argparse
+import random
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw
+
+
+def generate_image(size: int, defect: bool) -> Image.Image:
+    """Create a synthetic potato cross-section."""
+    img = Image.new("L", (size, size), color=0)
+    draw = ImageDraw.Draw(img)
+    draw.ellipse((0, 0, size - 1, size - 1), fill=210)
+
+    if defect:
+        radius = random.randint(size // 10, size // 4)
+        cx = random.randint(radius, size - radius)
+        cy = random.randint(radius, size - radius)
+        bbox = (cx - radius, cy - radius, cx + radius, cy + radius)
+        draw.ellipse(bbox, fill=40)
+
+    # Add slight noise using Pillow's effect_noise
+    noise = Image.effect_noise((size, size), 5).convert("L")
+    img = ImageChops.add(img, noise, scale=1.0, offset=0)
+    return img
+
+
+def build_dataset(outdir: Path, samples: int, size: int, test_split: float) -> None:
+    classes = ["defect", "healthy"]
+    for split in ["train", "test"]:
+        for cls in classes:
+            (outdir / split / cls).mkdir(parents=True, exist_ok=True)
+
+    n_test = int(samples * test_split)
+    for cls in classes:
+        for idx in range(samples):
+            defect = cls == "defect"
+            split = "test" if idx < n_test else "train"
+            img = generate_image(size, defect)
+            img.save(outdir / split / cls / f"{idx:04d}.png")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Synthetic dataset generator")
+    parser.add_argument("--outdir", type=Path, default=Path("data"), help="Output directory")
+    parser.add_argument("--samples", type=int, default=100, help="Images per class")
+    parser.add_argument("--size", type=int, default=128, help="Image size")
+    parser.add_argument("--test-split", type=float, default=0.2, help="Fraction used for test set")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    build_dataset(args.outdir, args.samples, args.size, args.test_split)
+    print(f"Dataset written to {args.outdir}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+torch
+torchvision
+pillow
+streamlit

--- a/train.py
+++ b/train.py
@@ -1,0 +1,92 @@
+"""Train a simple CNN to classify potato internal defects."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+
+class SimpleCNN(nn.Module):
+    """Minimal convolutional network for binary classification."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 16, kernel_size=3, padding=1)
+        self.pool = nn.MaxPool2d(2)
+        self.conv2 = nn.Conv2d(16, 32, kernel_size=3, padding=1)
+        self.fc1 = nn.Linear(32 * 32 * 32, 64)
+        self.fc2 = nn.Linear(64, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        x = self.pool(torch.relu(self.conv1(x)))
+        x = self.pool(torch.relu(self.conv2(x)))
+        x = x.view(x.size(0), -1)
+        x = torch.relu(self.fc1(x))
+        return self.fc2(x)
+
+
+def get_dataloaders(data_dir: Path, batch_size: int) -> tuple[DataLoader, DataLoader]:
+    transform = transforms.Compose([
+        transforms.Grayscale(),
+        transforms.ToTensor(),
+    ])
+    train_ds = datasets.ImageFolder(data_dir / "train", transform=transform)
+    test_ds = datasets.ImageFolder(data_dir / "test", transform=transform)
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_ds, batch_size=batch_size)
+    return train_loader, test_loader
+
+
+def train(model: nn.Module, loader: DataLoader, criterion, optimizer) -> float:
+    model.train()
+    running_loss = 0.0
+    for inputs, labels in loader:
+        optimizer.zero_grad()
+        outputs = model(inputs)
+        loss = criterion(outputs, labels)
+        loss.backward()
+        optimizer.step()
+        running_loss += loss.item() * inputs.size(0)
+    return running_loss / len(loader.dataset)
+
+
+def evaluate(model: nn.Module, loader: DataLoader) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for inputs, labels in loader:
+            outputs = model(inputs)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    return 100 * correct / total
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train potato defect classifier")
+    parser.add_argument("--data-dir", type=Path, default=Path("data"))
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--output", type=Path, default=Path("model.pth"))
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    train_loader, test_loader = get_dataloaders(args.data_dir, args.batch_size)
+    model = SimpleCNN()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    for epoch in range(args.epochs):
+        loss = train(model, train_loader, criterion, optimizer)
+        acc = evaluate(model, test_loader)
+        print(f"Epoch {epoch + 1}/{args.epochs} - Loss: {loss:.4f} - Test Acc: {acc:.2f}%")
+
+    torch.save(model.state_dict(), args.output)
+    print(f"Model saved to {args.output}")


### PR DESCRIPTION
## Summary
- generate synthetic potato cross-section images without external datasets
- train a lightweight CNN to classify internal defects
- provide a Streamlit app for "defect" vs "healthy" predictions

## Testing
- `python generate_dataset.py --outdir data --samples 5 --size 64 --test-split 0.4`
- `python train.py --data-dir data --epochs 1` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68afd5e802e48323ba9d187b2f6ddb05