### PR TITLE
Add Next.js 3D product showcase experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.pth
 *.pt
 data/
+showcase/.next/
+showcase/node_modules/
+showcase/.turbo/

--- a/showcase/app/globals.css
+++ b/showcase/app/globals.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  background: radial-gradient(circle at 30% 20%, rgba(125, 211, 252, 0.15), transparent 55%),
+    radial-gradient(circle at 70% 50%, rgba(236, 72, 153, 0.12), transparent 45%),
+    #030712;
+}
+
+section {
+  scroll-margin-top: 80px;
+}

--- a/showcase/app/layout.tsx
+++ b/showcase/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Lumen X | Luxury Instrument',
+  description: 'An immersive 3D showcase crafted for cinematic commerce experiences.'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="bg-night text-white">
+      <body className="min-h-screen bg-night font-body antialiased">{children}</body>
+    </html>
+  );
+}

--- a/showcase/app/page.tsx
+++ b/showcase/app/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import FeatureCards from '../components/FeatureCards';
+import FinalCTA from '../components/FinalCTA';
+import SpecsGrid from '../components/SpecsGrid';
+import StorySection from '../components/StorySection';
+
+const HeroSection = dynamic(() => import('../components/HeroSection'), {
+  ssr: false,
+  loading: () => (
+    <section className="flex min-h-screen items-center justify-center px-6">
+      <p className="text-sm uppercase tracking-[0.4em] text-white/60">Loading experience</p>
+    </section>
+  )
+});
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col gap-8 bg-transparent">
+      <HeroSection />
+      <FeatureCards />
+      <StorySection />
+      <SpecsGrid />
+      <FinalCTA />
+    </main>
+  );
+}

--- a/showcase/components/FeatureCards.tsx
+++ b/showcase/components/FeatureCards.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+const features = [
+  {
+    title: 'Acoustic intelligence',
+    description: 'Dual neural cores sample the environment 10,000x per second to recalibrate resonance.',
+    icon: '🧠'
+  },
+  {
+    title: 'Adaptive materials',
+    description: 'Phase-changing titanium lattice keeps the chassis cool and feather-light in every climate.',
+    icon: '🪶'
+  },
+  {
+    title: 'Tactile controls',
+    description: 'Solid-state dial delivers precise, haptic feedback with custom pressure profiles.',
+    icon: '🎛️'
+  },
+  {
+    title: 'Immersive audio',
+    description: 'Spatial Beam array locks the soundstage to your movement for cinematic depth.',
+    icon: '🔊'
+  }
+];
+
+export default function FeatureCards() {
+  return (
+    <section className="px-6 py-24 md:px-16">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+        <div className="flex flex-col gap-4">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/60">Essentials</p>
+          <h2 className="font-display text-4xl text-white md:text-5xl">Effortless sophistication, engineered within.</h2>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {features.map((feature, index) => (
+            <motion.article
+              key={feature.title}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.05, duration: 0.6, ease: 'easeOut' }}
+              viewport={{ once: true, amount: 0.3 }}
+              className="group rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl"
+            >
+              <div className="text-3xl">{feature.icon}</div>
+              <h3 className="mt-4 font-display text-2xl text-white">{feature.title}</h3>
+              <p className="mt-2 text-base text-slate-200">{feature.description}</p>
+              <div className="mt-6 h-px w-full scale-x-0 bg-white/40 transition duration-500 group-hover:scale-x-100" />
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/showcase/components/FinalCTA.tsx
+++ b/showcase/components/FinalCTA.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+export default function FinalCTA() {
+  return (
+    <section className="px-6 pb-24 pt-12 md:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-10 rounded-[48px] border border-white/10 bg-white/5 p-12 text-center">
+        <motion.h3
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, ease: 'easeOut' }}
+          viewport={{ once: true }}
+          className="font-display text-4xl text-white md:text-5xl"
+        >
+          The new ritual of sound arrives this fall.
+        </motion.h3>
+        <motion.button
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.98 }}
+          className="rounded-full bg-white px-12 py-4 text-sm font-semibold uppercase tracking-[0.4em] text-night"
+        >
+          Get notified
+        </motion.button>
+        <div className="h-px w-full bg-white/10" />
+        <p className="text-xs uppercase tracking-[0.3em] text-white/50">© {new Date().getFullYear()} Atelier Lumen</p>
+      </div>
+    </section>
+  );
+}

--- a/showcase/components/HeroCanvas.tsx
+++ b/showcase/components/HeroCanvas.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Canvas } from '@react-three/fiber';
+import { Suspense } from 'react';
+import Scene from './Scene';
+
+interface HeroCanvasProps {
+  progress: number;
+}
+
+export default function HeroCanvas({ progress }: HeroCanvasProps) {
+  return (
+    <div className="h-full w-full rounded-[40px] bg-gradient-to-br from-white/5 to-white/0 p-1">
+      <div className="h-full w-full rounded-[36px] bg-night/80 backdrop-blur-xl">
+        <Suspense fallback={<div className="flex h-full items-center justify-center text-sm text-white/60">Calibrating...</div>}>
+          <Canvas
+            shadows
+            gl={{ antialias: true, physicallyCorrectLights: true }}
+            camera={{ position: [0.2, 0.6, 5.5], fov: 32 }}
+          >
+            <Scene progress={progress} />
+          </Canvas>
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/showcase/components/HeroSection.tsx
+++ b/showcase/components/HeroSection.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { motion, useMotionValueEvent, useScroll, useTransform } from 'framer-motion';
+import { useMemo, useRef, useState } from 'react';
+import HeroCanvas from './HeroCanvas';
+
+export default function HeroSection() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ['start start', 'end start']
+  });
+  const [progress, setProgress] = useState(0);
+
+  useMotionValueEvent(scrollYProgress, 'change', (value) => {
+    setProgress(value);
+  });
+
+  const titleOpacity = useTransform(scrollYProgress, [0, 0.4], [1, 0.2]);
+  const titleY = useTransform(scrollYProgress, [0, 0.6], ['0%', '-40%']);
+  const ctaScale = useTransform(scrollYProgress, [0, 0.5], [1, 0.8]);
+
+  const stats = useMemo(
+    () => [
+      { label: 'Battery life', value: '48h adaptive' },
+      { label: 'Material', value: 'Recycled titanium shell' },
+      { label: 'Connectivity', value: '6G / UltraWide Mesh' }
+    ],
+    []
+  );
+
+  return (
+    <section ref={sectionRef} className="relative flex min-h-screen flex-col overflow-hidden px-6 pt-24 md:px-16">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(125,211,252,0.25),transparent_55%)]" />
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-12 pb-16 lg:flex-row lg:items-center">
+        <motion.div style={{ opacity: titleOpacity, y: titleY }} className="flex flex-1 flex-col gap-6 text-left">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-300">Lumen X</p>
+          <h1 className="font-display text-5xl leading-tight text-white md:text-6xl lg:text-7xl">
+            Precision audio. Sculpted for tomorrow.
+          </h1>
+          <p className="max-w-xl text-lg text-slate-200">
+            Experience a flagship instrument engineered with acoustic intelligence and an adaptive neural engine. Crafted
+            in titanium, balanced with artisanal leather, tuned with spatial resonance.
+          </p>
+          <motion.button
+            style={{ scale: ctaScale }}
+            className="w-fit rounded-full bg-white/10 px-10 py-4 text-sm font-semibold uppercase tracking-[0.3em] text-white backdrop-blur transition hover:bg-white/20"
+          >
+            Reserve yours
+          </motion.button>
+          <dl className="grid grid-cols-1 gap-6 pt-6 text-sm text-slate-300 sm:grid-cols-3">
+            {stats.map((stat) => (
+              <div key={stat.label} className="space-y-2 border-t border-white/10 pt-3">
+                <dt className="uppercase tracking-[0.3em] text-xs text-white/60">{stat.label}</dt>
+                <dd className="text-base text-white">{stat.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </motion.div>
+        <div className="relative flex h-[60vh] flex-1 items-center justify-center lg:h-[70vh]">
+          <HeroCanvas progress={progress} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/showcase/components/ProductModel.tsx
+++ b/showcase/components/ProductModel.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Float } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { useRef } from 'react';
+import * as THREE from 'three';
+
+interface ProductModelProps {
+  progress: number;
+}
+
+export default function ProductModel({ progress }: ProductModelProps) {
+  const group = useRef<THREE.Group>(null);
+
+  useFrame((_, delta) => {
+    if (!group.current) return;
+    const idleSpin = delta * 0.4;
+    const scrollSpin = progress * Math.PI * 2;
+    group.current.rotation.y = THREE.MathUtils.damp(group.current.rotation.y, scrollSpin, 3, delta) + idleSpin;
+    group.current.rotation.x = THREE.MathUtils.damp(group.current.rotation.x, 0.25 - progress * 0.2, 4, delta);
+    group.current.position.y = THREE.MathUtils.damp(group.current.position.y, Math.sin(progress * Math.PI) * 0.3, 3, delta);
+  });
+
+  return (
+    <group ref={group} position={[0, 0, 0]}>
+      <Float floatIntensity={1.2} rotationIntensity={0} speed={1.2}>
+        <mesh castShadow receiveShadow scale={[2.8, 1.2, 1.2]} position={[0, 0, 0]}>
+          <capsuleGeometry args={[0.6, 1.6, 32, 64]} />
+          <meshPhysicalMaterial
+            color="#f8fafc"
+            metalness={0.9}
+            roughness={0.1}
+            clearcoat={0.9}
+            clearcoatRoughness={0.1}
+            transmission={0.15}
+            reflectivity={1}
+            thickness={0.4}
+          />
+        </mesh>
+        <mesh position={[0, -0.6, 0]} rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[1.6, 0.08, 32, 100]} />
+          <meshStandardMaterial color="#38bdf8" metalness={0.8} roughness={0.2} />
+        </mesh>
+        <mesh position={[0, 0.5, 0]}>
+          <boxGeometry args={[0.2, 0.9, 1.7]} />
+          <meshStandardMaterial color="#0f172a" metalness={0.4} roughness={0.4} />
+        </mesh>
+      </Float>
+    </group>
+  );
+}

--- a/showcase/components/Scene.tsx
+++ b/showcase/components/Scene.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { ContactShadows, Environment } from '@react-three/drei';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import ProductModel from './ProductModel';
+
+interface SceneProps {
+  progress: number;
+}
+
+export default function Scene({ progress }: SceneProps) {
+  const { camera } = useThree();
+
+  useFrame(() => {
+    const targetPosition = new THREE.Vector3(
+      Math.sin(progress * Math.PI) * 0.8,
+      0.4 + progress * 0.3,
+      5 - progress * 2
+    );
+    camera.position.lerp(targetPosition, 0.05);
+    camera.lookAt(0, 0.2, 0);
+  });
+
+  const keyLight = useMemo(() => new THREE.Color('#f5f5f5'), []);
+
+  return (
+    <>
+      <color attach="background" args={[0, 0, 0, 0]} />
+      <ambientLight intensity={0.35} />
+      <directionalLight
+        position={[4, 6, 3]}
+        castShadow
+        intensity={1.4}
+        color={keyLight}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+      />
+      <spotLight
+        position={[-4, 2.5, 2]}
+        angle={0.6}
+        penumbra={0.5}
+        intensity={0.6}
+        color="#93c5fd"
+      />
+      <ProductModel progress={progress} />
+      <ContactShadows
+        opacity={0.4}
+        position={[0, -1.1, 0]}
+        blur={2.6}
+        far={8}
+        width={12}
+        height={12}
+      />
+      <Environment preset="studio" background={false} />
+    </>
+  );
+}

--- a/showcase/components/SpecsGrid.tsx
+++ b/showcase/components/SpecsGrid.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+const specs = [
+  { label: 'Processor', value: 'NovaSense X2 neural array' },
+  { label: 'Drivers', value: 'Dual 40mm graphene, adaptive waveguides' },
+  { label: 'Latency', value: '0.4 ms spatial sync' },
+  { label: 'Charging', value: 'MagSafe Qi3 / 15W solar dock' },
+  { label: 'Sensors', value: 'Bio-acoustic pulse, ambient temp, gesture radar' },
+  { label: 'Ingress', value: 'IP68 + nano-sealed acoustics' }
+];
+
+export default function SpecsGrid() {
+  return (
+    <section className="px-6 py-24 md:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-12">
+        <div className="flex flex-col gap-4">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/60">Tech specs</p>
+          <h2 className="font-display text-4xl text-white md:text-5xl">Numbers that feel otherworldly.</h2>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {specs.map((spec, index) => (
+            <motion.div
+              key={spec.label}
+              initial={{ opacity: 0, scale: 0.95 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.5, delay: index * 0.05 }}
+              viewport={{ once: true, amount: 0.3 }}
+              className="rounded-3xl border border-white/10 bg-white/5 p-6"
+            >
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">{spec.label}</p>
+              <p className="mt-3 text-lg text-white">{spec.value}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/showcase/components/StorySection.tsx
+++ b/showcase/components/StorySection.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+
+export default function StorySection() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start end', 'end start'] });
+  const y = useTransform(scrollYProgress, [0, 1], ['10%', '-10%']);
+  const opacity = useTransform(scrollYProgress, [0, 0.3, 1], [0.2, 1, 0.2]);
+
+  return (
+    <section className="px-6 py-24 md:px-16">
+      <div ref={ref} className="mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[40px] border border-white/10 bg-gradient-to-br from-white/5 to-white/0 p-10 text-center">
+        <motion.p style={{ y, opacity }} className="font-display text-4xl leading-relaxed text-white md:text-5xl">
+          Crafted between Milan and Tokyo, Lumen X embodies a new ritual of listening—one where tactile precision meets
+          soulful warmth. Every surface is honed to invite touch, while the adaptive engine dissolves the border between
+          studio and sanctuary.
+        </motion.p>
+        <p className="text-sm uppercase tracking-[0.4em] text-white/50">Story</p>
+      </div>
+    </section>
+  );
+}

--- a/showcase/next-env.d.ts
+++ b/showcase/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/showcase/next.config.js
+++ b/showcase/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "luxe-product-showcase",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.99.0",
+    "@react-three/fiber": "^8.15.16",
+    "framer-motion": "^10.18.0",
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "three": "^0.164.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.9",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/showcase/postcss.config.js
+++ b/showcase/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/showcase/tailwind.config.js
+++ b/showcase/tailwind.config.js
@@ -1,0 +1,21 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        night: '#030712',
+        mist: '#f2f6ff',
+        accent: '#7dd3fc'
+      },
+      fontFamily: {
+        display: ['"SF Pro Display"', 'Inter', 'sans-serif'],
+        body: ['"SF Pro Text"', 'Inter', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};

--- a/showcase/tsconfig.json
+++ b/showcase/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a standalone Next.js + Tailwind + Three.js experience under `showcase/`
- implement a hero section with a scroll-reactive 3D scene, feature highlights, story, specs, and CTA blocks styled in an Apple-inspired aesthetic
- configure Tailwind, TypeScript, and project metadata for a production-ready immersive marketing page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d7d076f0483238ffb258738775960)